### PR TITLE
Move building docker image ahead of editing cwl

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,6 +90,15 @@ jobs:
           echo "::set-env name=NEW_VERSION::$new_version"
           echo "::set-env name=NEW_GIT_TAG::$new_tag"
 
+      - name: Publish Docker Image
+        id: docker_publish
+        uses: docker/build-push-action@v1
+        with:
+          repository: sagebionetworks/${{ github.event.repository.name }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          tags: ${{ env.NEW_VERSION }},latest
+
       - name: Edit CWL file tool version
         id: edit_cwl
         run: |
@@ -106,12 +115,3 @@ jobs:
           git commit -a -m "Update docker image version in CWL tool to ${{ env.NEW_VERSION }}"
           git tag ${{ env.NEW_GIT_TAG }}
           git push && git push --tags
-
-      - name: Publish Docker Image
-        id: docker_publish
-        uses: docker/build-push-action@v1
-        with:
-          repository: sagebionetworks/${{ github.event.repository.name }}
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          tags: ${{ env.NEW_VERSION }},latest


### PR DESCRIPTION
This moves the docker_publish step in the build job ahead of the edit_cwl step. This is a first step (pardon the pun) in working out ways to recover gracefully when builds error.